### PR TITLE
Make description an optional field

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ SYNOPSIS
 
 **UPLOAD**
 
-	glaciercmd --description <DESC> --input <INPUT> -u --vault <VAULT>
+	glaciercmd [--description <DESC>] --input <INPUT> -u --vault <VAULT>
 
 **DOWNLOAD**
 
@@ -82,7 +82,7 @@ Download file from a vault. Note: this command will block until the file has bee
 
 **--description** *DESC* 
 
-Use this description
+Use this description. If omitted the name of the file is used.
 
 **-h** **--help** *COMMAND* 
 

--- a/src/nl/nekoconeko/glaciercmd/GlacierClient.java
+++ b/src/nl/nekoconeko/glaciercmd/GlacierClient.java
@@ -74,8 +74,14 @@ public class GlacierClient {
 	protected UploadResult uploadFile(String vault, String filename, String description) {
 		ArchiveTransferManager atm = new ArchiveTransferManager(this.client, this.credentials);
 		UploadResult res = null;
-		try {
-			res = atm.upload(vault, description, new File(filename));
+                
+                File toUpload = new File(filename);
+                if ( description == null ) {
+                    description = toUpload.getName();
+                }
+                
+                try {
+			res = atm.upload(vault, description, toUpload);
 		} catch (AmazonServiceException e) {
 			System.err.println("An error occured at Amazon AWS: " + e.getLocalizedMessage());
 			System.exit(1);

--- a/src/nl/nekoconeko/glaciercmd/config/ConfigMode.java
+++ b/src/nl/nekoconeko/glaciercmd/config/ConfigMode.java
@@ -35,6 +35,11 @@ public class ConfigMode extends Options {
 		opt.setRequired(true);
 		this.addOption(opt);
 	}
+        
+        public void addOptionalOption(Option opt) {
+                opt.setRequired(false);
+                this.addOption(opt);
+        }
 
 	public List<ConfigParameter> getAllOptions() {
 		List<ConfigParameter> all = new ArrayList<ConfigParameter>(this.getOptions().size());

--- a/src/nl/nekoconeko/glaciercmd/config/ConfigModes.java
+++ b/src/nl/nekoconeko/glaciercmd/config/ConfigModes.java
@@ -96,7 +96,7 @@ public class ConfigModes {
 		upload.addRequiredOption(uploadmode);
 		upload.addRequiredOption(vault);
 		upload.addRequiredOption(inputfile);
-		upload.addRequiredOption(description);
+		upload.addOptionalOption(description);
 
 		// Options for download
 		ConfigMode download = new ConfigMode();


### PR DESCRIPTION
**Why?**
When I was uploading archives to Glacier I didn't like I had to enter the description of the archive because it's file name was unique in our system anyway. Using the file name as a descriptor would therefore be very useful. I already wrote a script which did this, but is felt like a hack.
Since I assumed may be more people felt this way, I wanted to fix it.

**How?**
I modified the program to include a method addOptionalParameter and made description optional. In case description is omitted, it will receive a default value when uploading which in turn depends on the file name you are trying to upload.

**Result:**
In case the description option is omitted, the file name without the directory name is used as a description. 
